### PR TITLE
Update pmd_rules_java_design.html

### DIFF
--- a/pmd-6.40.0/pmd_rules_java_design.html
+++ b/pmd-6.40.0/pmd_rules_java_design.html
@@ -3617,7 +3617,7 @@ within those methods.</p>
 
 <div class="language-java highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kd">public</span> <span class="kd">class</span> <span class="nc">Foo</span> <span class="o">{</span>
     <span class="kd">private</span> <span class="kt">int</span> <span class="n">x</span><span class="o">;</span>  <span class="c1">// no reason to exist at the Foo instance level</span>
-    <span class="kd">public</span> <span class="kt">void</span> <span class="nf">foo</span><span class="o">(</span><span class="kt">int</span> <span class="n">y</span><span class="o">)</span> <span class="o">{</span>
+    <span class="kd">public</span> <span class="kt">int</span> <span class="nf">foo</span><span class="o">(</span><span class="kt">int</span> <span class="n">y</span><span class="o">)</span> <span class="o">{</span>
      <span class="n">x</span> <span class="o">=</span> <span class="n">y</span> <span class="o">+</span> <span class="mi">5</span><span class="o">;</span>
      <span class="k">return</span> <span class="n">x</span><span class="o">;</span>
     <span class="o">}</span>


### PR DESCRIPTION
A grammar error about the code example in document (pmd_rules_java_design.html), the return value should be `int`.